### PR TITLE
Issue #20 - Add support for data_update_method

### DIFF
--- a/jsumfields.php
+++ b/jsumfields.php
@@ -1909,6 +1909,11 @@ function jsumfields_civicrm_triggerInfo(&$info, $triggerTableName) {
     return;
   }
 
+  // check if we need to generate triggers or if it will be updated using cron
+  if (sumfields_get_setting('data_update_method','via_triggers') != 'via_triggers') {
+    return;
+  }
+
   // If any enabled fields have 'jsumfields_extra' defined, formulate
   // a trigger for them and add to $info.
   // Our triggers all use custom fields. CiviCRM, when generating


### PR DESCRIPTION
Before:
In `/civicrm/admin/setting/sumfields` page, upon adding new summary fields from jsumfields, triggers are always created even if we check the box `How often should summary data be updated?` to `When ever the cron job is run (increases performance on large installation)`
![Screenshot 2021-09-02 at 14-02-04 Summary Fields Administration Fondation pour les générations futures](https://user-images.githubusercontent.com/372004/131894212-d415ab5c-8b18-4ab3-8e55-5844a1455b6b.png)

After:
If we check the box `How often should summary data be updated?` to `When ever the cron job is run (increases performance on large installation)`, the triggers are not created and the jsumfields are only updated when the `SumFields.Gendata` cron job is ran.