### PR TITLE
Smarty 3+ compatibility fix

### DIFF
--- a/jsumfields.php
+++ b/jsumfields.php
@@ -18,7 +18,7 @@ function jsumfields_civicrm_apiWrappers(&$wrappers, $apiRequest) {
 function jsumfields_civicrm_buildForm($formName, &$form) {
   if ($formName == 'CRM_Sumfields_Form_SumFields') {
     $tpl = CRM_Core_Smarty::singleton();
-    $fieldsets = $tpl->_tpl_vars['fieldsets'];
+    $fieldsets = $tpl->get_template_vars()['fieldsets'];
 
     // Get jsumfields definitions, because we need the fieldset names as a target
     // for where to insert our option fields


### PR DESCRIPTION
This code fails in Smarty 3+. See https://github.com/civicrm/civicrm-core/pull/27589 for an example of this change in core.

Once Smarty 2 is dropped, we can change these again to getTemplateVars() but for now we use get_template_vars() and rely on the Civi Smarty compatibility layer.