### PR TITLE
Update call to deprecated Smarty::get_template_vars

### DIFF
--- a/jsumfields.php
+++ b/jsumfields.php
@@ -18,7 +18,7 @@ function jsumfields_civicrm_apiWrappers(&$wrappers, $apiRequest) {
 function jsumfields_civicrm_buildForm($formName, &$form) {
   if ($formName == 'CRM_Sumfields_Form_SumFields') {
     $tpl = CRM_Core_Smarty::singleton();
-    $fieldsets = $tpl->get_template_vars()['fieldsets'];
+    $fieldsets = $tpl->getTemplateVars()['fieldsets'];
 
     // Get jsumfields definitions, because we need the fieldset names as a target
     // for where to insert our option fields


### PR DESCRIPTION
Replaces deprecated function name with the forward-compat equivalent.

Note: the new getTemplateVars function has been available since CiviCRM 5.70.