### PR TITLE
Remove calls to deprecated CRM_Utils_Array::value

### DIFF
--- a/jsumfields.php
+++ b/jsumfields.php
@@ -63,10 +63,10 @@ function jsumfields_civicrm_buildForm($formName, &$form) {
 function jsumfields_civicrm_postProcess($formName, &$form) {
   if ($formName == 'CRM_Sumfields_Form_SumFields') {
     // Save option fields as submitted.
-    sumfields_save_setting('jsumfields_relatedcontrib_financial_type_ids', CRM_Utils_Array::value('jsumfields_relatedcontrib_financial_type_ids', $form->_submitValues));
-    sumfields_save_setting('jsumfields_relatedcontrib_relationship_type_ids', CRM_Utils_Array::value('jsumfields_relatedcontrib_relationship_type_ids', $form->_submitValues));
-    sumfields_save_setting('jsumfields_grant_status_ids', CRM_Utils_Array::value('jsumfields_grant_status_ids', $form->_submitValues));
-    sumfields_save_setting('jsumfields_grant_type_ids', CRM_Utils_Array::value('jsumfields_grant_type_ids', $form->_submitValues));
+    sumfields_save_setting('jsumfields_relatedcontrib_financial_type_ids', $form->_submitValues['jsumfields_relatedcontrib_financial_type_ids'] ?? NULL);
+    sumfields_save_setting('jsumfields_relatedcontrib_relationship_type_ids', $form->_submitValues['jsumfields_relatedcontrib_relationship_type_ids'] ?? NULL);
+    sumfields_save_setting('jsumfields_grant_status_ids', $form->_submitValues['jsumfields_grant_status_ids'] ?? NULL);
+    sumfields_save_setting('jsumfields_grant_type_ids', $form->_submitValues['jsumfields_grant_type_ids'] ?? NULL);
 
     if ($form->_submitValues['when_to_apply_change'] == 'on_submit') {
       // Update our own trigger data, as needed.
@@ -1853,8 +1853,8 @@ function jsumfields_civicrm_triggerInfo(&$info, $triggerTableName) {
     if (!empty($custom['fields'][$base_column_name]['jsumfields_extra'])) {
       foreach ($custom['fields'][$base_column_name]['jsumfields_extra'] as $extra) {
 
-        $triggerSql = CRM_Utils_Array::value('trigger_sql', $extra);
-        $customTriggerTableName = CRM_Utils_Array::value('trigger_table', $extra);
+        $triggerSql = $extra['trigger_sql'] ?? NULL;
+        $customTriggerTableName = $extra['trigger_table'] ?? NULL;
 
         if (empty($triggerSql) || empty($customTriggerTableName)) {
           // This extra trigger is not fully defined, so just skip it.


### PR DESCRIPTION
Replaces deprecated function with equivalent null-coalescing operator. Behavior should be the same before/after.